### PR TITLE
Add cache-control for static files

### DIFF
--- a/rootfs/nginx/sites-enabled/selfoss.conf
+++ b/rootfs/nginx/sites-enabled/selfoss.conf
@@ -17,6 +17,20 @@ server {
     deny all;
   }
 
+  location ~ /.*\.(?:css|js)$ {
+    expires 7d;
+    add_header Pragma public;
+    add_header Cache-Control "public, must-revalidate, proxy-revalidate";
+    try_files $uri /public/$uri /index.php$is_args$args;
+  }
+
+  location ~ /.*\.(?:gif|jpe?g|png|ico|otf|eot|svg|ttf|woff|woff2)$ {
+    expires 30d;
+    add_header Pragma public;
+    add_header Cache-Control "public, must-revalidate, proxy-revalidate";
+    try_files $uri /public/$uri /index.php$is_args$args;
+  }
+
   location / {
     try_files $uri /public/$uri /index.php$is_args$args;
   }


### PR DESCRIPTION
Hi,
Client side cache can be enabled easily for static files by adding `exposes 30d` inside your `location /` block. As every files in the `/selfoss/public` folder are static, it will match for all of them.

Thanks!