### PR TITLE
Add pgsql and mysql PDO packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,8 @@ RUN echo "@community http://nl.alpinelinux.org/alpine/v3.7/community" >> /etc/ap
     php7-curl@community \
     php7-iconv@community \
     php7-mcrypt@community \
+    php7-pdo_mysql@community \
+    php7-pdo_pgsql@community \
     php7-pdo_sqlite@community \
     php7-ctype@community \
     php7-session@community \


### PR DESCRIPTION
Hi,
Before 45259954d9c82eb09148e3113dfaf2ff463b45c5, Postgresql and Mysql/Mariadb PDO drivers were included. Since you moved to alpine directly, they are not. It includes them allow selfoss to works again with these RDBMS.

Thanks!